### PR TITLE
updating to add default value for HttpsPort

### DIFF
--- a/content/BlazorBffOpenIDConnect/.template.config/template.json
+++ b/content/BlazorBffOpenIDConnect/.template.config/template.json
@@ -19,29 +19,40 @@
         "type":"solution"
     },
     "sourceName": "BlazorBffOpenIDConnect",
-    "preferNameDirectory": "true",
+    "preferNameDirectory": true,
     "guids": [
 		"CFDA20EC-841D-4A9C-A95C-2C674DA96F23",
 		"74A2A84B-C3B8-499F-80ED-093854CABDEA",
 		"BD70F728-398A-4A88-A7C7-A3D9B78B5AE6"
     ],
 	"symbols": {
+		"HttpsPortCustom": {
+		  "type": "parameter",
+		  "datatype": "integer",
+		  "description": "Port number to use for the HTTPS endpoint in launchSettings.json.",
+		  "defaultValue": "44347"
+		},
 		"HttpsPortGenerated": {
 		  "type": "generated",
 		  "generator": "port",
 		  "parameters": {
-			"low": 44300,
-			"high": 44399
+		  "low": 44300,
+		  "high": 44399
 		  }
 		},
 		"HttpsPortReplacer": {
 		  "type": "generated",
 		  "generator": "coalesce",
 		  "parameters": {
-			"sourceVariableName": "HttpsPort",
-			"fallbackVariableName": "HttpsPortGenerated"
+		  "sourceVariableName": "HttpsPortCustom",
+		  "fallbackVariableName": "HttpsPortGenerated"
 		  },
 		  "replaces": "44348"
 		}
-   }
+   },
+   "primaryOutputs": [
+    {
+      "path": "BlazorBffOpenIDConnect.sln"
+    }
+  ]
 }

--- a/content/BlazorBffOpenIDConnect/.template.config/template.json
+++ b/content/BlazorBffOpenIDConnect/.template.config/template.json
@@ -30,7 +30,8 @@
 		  "type": "parameter",
 		  "datatype": "integer",
 		  "description": "Port number to use for the HTTPS endpoint in launchSettings.json.",
-		  "defaultValue": "44347"
+		  "defaultValue": "44347",
+		  "isRequired": true
 		},
 		"HttpsPortGenerated": {
 		  "type": "generated",


### PR DESCRIPTION
I made the following changes.
 - Changed `HttpsPort` to `HttpsPortCustom` and added a default value. I think VS special cases "HttpsPort" but I'll need to discuss with Phil when he gets back from vacation.
 - Added default value for `HttpsPortCustom`. If the user removes the default value and doesn't provide a new value, nothing will be created. VS has some bug here, I'll need to discuss with Phil when he is back to see what's happening.
 - Changed bool `"true"` to `true`
 - Added a `primaryOutputs` so that VS can find the `.sln` file