### PR TITLE
Update antiForgeryToken.js

### DIFF
--- a/BlazorBffOpenIdConnect/Client/wwwroot/antiForgeryToken.js
+++ b/BlazorBffOpenIdConnect/Client/wwwroot/antiForgeryToken.js
@@ -1,5 +1,11 @@
 function getAntiForgeryToken() {
     var elements = document.getElementsByName('__RequestVerificationToken');
+
+    // There can be two __RequestVerificationToken inputs. 
+    elements = Array.prototype.slice.call(elements).sort(function (a, b) {
+      return b.value.length - a.value.length;
+    });
+    
     if (elements.length > 0) {
         return elements[0].value
     }


### PR DESCRIPTION
There can be two `__RequestVerificationTokens` inputs. One from the _Host and one from the component `AntiForgeryTokenInput.razor` which is used manually in forms like on the `MainLayout.razor` for POSTing to /logout.

Some components/pages might try to obtain the token and get the input from `AntiForgeryTokenInput.razor` which has not yet been initialized, and will be null.

This simple fix sorts the inputs by the length of their value, thus putting the non-null ones at the top.